### PR TITLE
docs(index.html): improve a sentence in the intro

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,7 +101,7 @@
             container.</li>
           <li>Changes are frequently pushed to a continuous integration server that
             runs the automated tests. LocalStack provisions all required "cloud"
-            resources</li>
+            resources in the continuous integration server environment.</li>
           <li>Once all tests are green, you flip the switch and the application can
             be seamlessly deployed to the real AWS cloud environment.</li>
         </ol>


### PR DESCRIPTION
### What does this PR do?

This pull requests contains a change that elaborates more on how resources are provisioned in the CI environment in section 2 of the intro.

### Background info

I am making this suggestion as I think this would be more clear to the end user. If the team decides not to implement my additions and want to end the sentence with `resources`, I can simply push an additional commit to add a `.` to the end of `resources` as it is missing a period.

Thank you to all the contributors that are working on this project. 