### PR TITLE
page for localstack cockpit

### DIFF
--- a/config/_default/menus.toml
+++ b/config/_default/menus.toml
@@ -41,10 +41,10 @@
   url = "https://app.localstack.cloud"
   weight = 30
 
-# [[products]]
-#   name = "LocalStack Cockpit"
-#   url = "/products/cockpit"
-#   weight = 40
+ [[products]]
+   name = "LocalStack Cockpit"
+   url = "/products/cockpit"
+   weight = 40
 
 [[social]]
   name = "Twitter"

--- a/content/products/cockpit/index.html
+++ b/content/products/cockpit/index.html
@@ -22,17 +22,12 @@ buttons:
         </div>
         <div class="row justify-content-center text-center">
             <div class="col-12">
-                <a class="btn btn-primary btn-lg disabled">
-                    Coming Soon!
-                </a>
-                <!--
                 <a href="https://docs.localstack.cloud/getting-started/cockpit" class="btn btn-outline-primary btn-lg mr-2">
                     Learn more
                 </a>
                 <a class="btn btn-primary btn-lg" data-bs-toggle="modal" href="#cockpitDownloadModal" role="button">
                     Download
                 </a>
-                -->
             </div>
         </div>
     </div>


### PR DESCRIPTION
This PR adds a page for the localstack cockpit.

- [x] basic stub content
- [x] include download form modal
- [x] make download modal functional using client-side javascript (process backend response of `POST /download`)
- [x] restructure "Features" nav button into "Products" with a drop down
- [x] update preview images with looping videos/new screenshots
- [x] point "Learn More" button to correct docs
- [x] polish the entire thing

we will wait for @HarshCasper to prepare an announcement for Monday Feb 7., then we can merge this PR :-) 