### PR TITLE
fix RSS feeds

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,1 @@
+title = "LocalStack"

--- a/layouts/index.rss.xml
+++ b/layouts/index.rss.xml
@@ -1,0 +1,27 @@
+{{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\" ?>" | safeHTML }}
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>{{ if eq  .Title  .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}{{ end }}</title>
+    <link>{{ .RelPermalink }}</link>
+    <description>Recent content {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
+    <generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}
+    <language>{{.}}</language>{{end}}{{ with .Site.Author.email }}
+    <managingEditor>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Author.email }}
+    <webMaster>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
+    <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
+    <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
+    {{ with .OutputFormats.Get "RSS" }}
+        {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .RelPermalink .MediaType | safeHTML }}
+    {{ end }}
+    {{ range first 25 (where .Site.RegularPages "Type" "in" (slice "jobs" "blog")) }}
+    <item>
+      <title>{{ .Title }}</title>
+      <link>{{ .RelPermalink }}</link>
+      <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+      {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
+      <guid>{{ .RelPermalink }}</guid>
+      <description>{{ .Summary | html }}</description>
+    </item>
+    {{ end }}
+  </channel>
+</rss>


### PR DESCRIPTION
This PR fixes the RSS feeds by:
- Setting a page title (which is used in the `title` tag of the RSS feed).
- Setting a separate RSS feed for the index (`index.rss.xml`) which only shows entries from the blog and the jobs section.

The RSS feed for a section can be found at `/index.xml`, f.e.:
- The global RSS feed: https://localstack.cloud/index.xml
- The blog RSS feed: https://localstack.cloud/blog/index.xml

We can verify the fix by testing the feature branch deployment.