### PR TITLE
fix list styles (bold ordered list markers, full circle sub-lists)

### DIFF
--- a/assets/scss/layouts/_pages.scss
+++ b/assets/scss/layouts/_pages.scss
@@ -51,3 +51,13 @@ p.meta {
     @extend .rounded-2;
     padding: 1rem;
 }
+
+// use full discs for all lists (primary and sublists) to increase the readability
+ul {
+  list-style: disc;
+}
+
+// make ordered list markers (1., 2.,...) bold to increase the readability
+ol li::marker {
+  font-weight: bold;
+}


### PR DESCRIPTION
This PR changes the styles of lists such that they become a bit more readable:
- Change the font weight of ordered list markers to `bold` (i.e. print the numbers / characters of ordered lists in bold).
- Use the full circle also for sub-lists (instead of the default non-filled circle).

Since there is no page using sublists or numbered lists on the website yet, I created some screenshots of parts of #57 with and without the style changes:
- Without the changes of this PR:
  ![1-pre-css](https://user-images.githubusercontent.com/2796604/180992591-788e663b-f1be-42c6-95c3-f5aebedab0e2.png)
- With the changes of this PR:
  ![2-post-css](https://user-images.githubusercontent.com/2796604/180992641-14022f5a-8f80-4758-8348-67a08d38bee3.png)

The preview deployment can be used to verify that the style changes don't break any existing pages.