### PR TITLE
introduce small change to margin of Timeline section

### DIFF
--- a/layouts/company/list.html
+++ b/layouts/company/list.html
@@ -2,15 +2,15 @@
 {{ partial "heroes/base.html" (dict "Title" .Title "Subtitle" .Description "HeroIcon" "cloud" ) }}
 
 <section class="section container">
-    <p class="text-center mb-0">
+    <p class="text-center">
       At LocalStack, we believe that empowering developers and giving them full control over their environments is the key to driving innovation. We live and breathe developer experience in everything we do, and have set out to pursue the audacious goal of seamlessly integrating and complementing the centralized nature of the cloud with our suite of tools that allow developers to build decentralized dev & test loops for full flexibility, control, and unprecedented cloud development speed.
     </p>
     <br/>
-    <p class="text-center mb-0">
+    <p class="text-center">
       Only made possible through countless contributions from the open source community and our top-notch team, we have managed to revolutionize the cloud development experience. Today, we are fortunate to be working with a growing community of users and customers, with 100s of thousand developers using LocalStack on a regular basis, and a growing number of organizations leveraging our platform to optimize their development pipelines and team collaboration flows.
     </p>
 
-    <div class="strike-dark">
+    <div class="strike-dark mt-6">
       <h2 class="text-center">Timeline</h2>
     </div>
     


### PR DESCRIPTION
adjusted the margin/padding of some elements on the about us (company) page, to keep styling consistent with remaining design

old:
![screencapture-localstack-cloud-company-2022-09-07-08_18_42](https://user-images.githubusercontent.com/39307517/188803415-a120c4d4-9abf-484e-a6db-4465c36ca15f.png)

new:
![screencapture-localhost-1313-company-2022-09-07-08_18_22](https://user-images.githubusercontent.com/39307517/188803471-0f949ab5-7939-4148-8b99-f823cf8ff76f.png)
