### PR TITLE
Update instructions for dev contest

### DIFF
--- a/content/dev-contest/instructions.md
+++ b/content/dev-contest/instructions.md
@@ -41,7 +41,7 @@ First we create the Lambda using the provided zip file:
 ```bash
 awslocal lambda create-function \
         --function-name localstack-demo-lambda \
-        --runtime python3.8 \
+        --runtime python3.9 \
         --handler handler.handler \
         --zip-file fileb://demo-lambda.zip \
         --role arn:aws:iam::000000000000:role/lambda-ex
@@ -50,6 +50,7 @@ awslocal lambda create-function \
 Next, we run the lambda - make sure you use the email address you provided when signing up for Localstack:
 ```bash
 awslocal lambda invoke \
+        --cli-binary-format raw-in-base64-out \
         --function-name localstack-demo-lambda \
         --payload '{"email": "YOUR EMAIL ADDRESS"}' /tmp/lambda.out
 ```

--- a/content/dev-contest/instructions.md
+++ b/content/dev-contest/instructions.md
@@ -48,7 +48,18 @@ awslocal lambda create-function \
 ```
 
 Next, we run the lambda - make sure you use the email address you provided when signing up for Localstack:
+
 ```bash
+# aws-cli v1
+awslocal lambda invoke \
+        --function-name localstack-demo-lambda \
+        --payload '{"email": "YOUR EMAIL ADDRESS"}' /tmp/lambda.out
+```
+
+If you're using the **aws-cli v2** you will need to add `--cli-binary-format raw-in-base64-out`
+
+```bash
+# aws-cli v2
 awslocal lambda invoke \
         --cli-binary-format raw-in-base64-out \
         --function-name localstack-demo-lambda \


### PR DESCRIPTION
Adding flag to avoid `Invalid base64: "{"email": "<mail>"}"` errors when running invoke