### PR TITLE
Add snippet for new Google Analytics GA4 tracking

### DIFF
--- a/layouts/partials/head/script-header.html
+++ b/layouts/partials/head/script-header.html
@@ -1,3 +1,4 @@
+<!-- old snippet - TODO remove -->
 <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
@@ -5,6 +6,15 @@
   })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
   ga('create', 'UA-101988473-1', 'auto');
   ga('send', 'pageview');
+</script>
+
+<!-- new tracking snippet (G4) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-QRFTZPWGB7"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-QRFTZPWGB7');
 </script>
 
 <script defer


### PR DESCRIPTION
Add code snippet for new Google Analytics GA4 tracking, see here: https://support.google.com/analytics/answer/10089681?sjid=16080059075568150917-EU

The old snippet is still in there as we're bootstrapping the new GA4 property, but will become defunct on July 1st. /cc @HarshCasper 