### PR TITLE
update docker pulls & slack members

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -47,7 +47,7 @@
         <span style="font-size: 0.875rem; font-weight: 700">CONTRIBUTORS</span>
       </div>
       <div class="col-12 col-sm-6 col-lg-3">
-        <span style="font-size: 2.5rem; font-weight: 800">20 k<span style="color: #79F0A9">+</span></span><br>
+        <span style="font-size: 2.5rem; font-weight: 800">25 k<span style="color: #79F0A9">+</span></span><br>
         <span style="font-size: 0.87rem; font-weight: 700">SLACK MEMBERS</span>
       </div>
       <div class="col-12 col-sm-6 col-lg-3">
@@ -55,7 +55,7 @@
         <span style="font-size: 0.87rem; font-weight: 700">GITHUB STARS</span>
       </div>
       <div class="col-12 col-sm-6 col-lg-3">
-        <span style="font-size: 2.5rem; font-weight: 800">150 M<span style="color: #79F0A9">+</span></span><br>
+        <span style="font-size: 2.5rem; font-weight: 800">160 M<span style="color: #79F0A9">+</span></span><br>
         <span style="font-size: 0.87rem; font-weight: 700">DOCKER PULLS</span>
       </div>
     </div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -47,7 +47,7 @@
         <span style="font-size: 0.875rem; font-weight: 700">CONTRIBUTORS</span>
       </div>
       <div class="col-12 col-sm-6 col-lg-3">
-        <span style="font-size: 2.5rem; font-weight: 800">25 k<span style="color: #79F0A9">+</span></span><br>
+        <span style="font-size: 2.5rem; font-weight: 800">20 k<span style="color: #79F0A9">+</span></span><br>
         <span style="font-size: 0.87rem; font-weight: 700">SLACK MEMBERS</span>
       </div>
       <div class="col-12 col-sm-6 col-lg-3">


### PR DESCRIPTION
this PR updates:
1. numbers of docker pulls. You can validate with `curl -s https://hub.docker.com/v2/repositories/localstack/localstack/ | jq -c "{star_count: .star_count, pull_count: .pull_count}"`
2. number of slack community members. Currently the #general channel includes 25'315 members - I'm not sure if this is the right way to determine slack members (I'm not an admin). Maybe as an admin there's a more proper way.