### PR TITLE
update formatting and change some emails to reference support email address

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -234,7 +234,7 @@ function preSelectPlatformArtifact(artifacts) {
         alert('Error occurred: ' + data.message);
       } else if (status === 404) {
         cockpitDownloadModal.hide();
-        showError("Error: " + data.message, "This is probably a problem on our side, sorry! Please contact us and let us know at info@localstack.cloud");
+        showError("Error: " + data.message, "This is probably a problem on our side, sorry! Please contact us and let us know at support@localstack.cloud");
       } else {
         cockpitDownloadModal.hide();
         showError("Unknown error occurred", "Please contact us and let us know. Thanks!");

--- a/content/contact/_index.md
+++ b/content/contact/_index.md
@@ -14,7 +14,8 @@ Below you can find some pointers for contacting us, as well as getting in touch 
 
 ### Issues and Bug Reports
 
-For any bug reports, please first consult the main Github repository: [https://github.com/localstack/localstack](https://github.com/localstack/localstack). Chances are that a similar issue may have already been posted by other users in the past. Github has an excellent search function, which may help find existing answers to your questions.
+For any bug reports, please first consult the main Github repository: [https://github.com/localstack/localstack](https://github.com/localstack/localstack).
+Chances are that a similar issue may have already been posted by other users in the past. Github has an excellent search function, which may help find existing answers to your questions.
 
 If you cannot find a solution in the existing issues, please raise a bug report directly in Github. By tagging the issue with the label `PRO`, we'll try our best to prioritize your request.
 
@@ -29,7 +30,7 @@ Please make sure to always include the following details in your bug report:
 
 Please join us in our Slack channel: [https://localstack-community.slack.com](https://localstack-community.slack.com).
 
-Don't have access to `localstack-community` yet? Please contact us at [info@localstack.cloud](mailto:info@localstack.cloud) to receive an invite or join through this [invite link](http://slack.localstack.cloud/).
+Don't have access to `localstack-community` yet? Join us through this [invite link](http://slack.localstack.cloud/).
 
 ### Forum
 
@@ -37,4 +38,4 @@ To participate in wider community discussions and steer the development of Local
 
 ### Email
 
-For any administrative questions regarding your account (e.g., subscriptions, billing), please contact us directly at [info@localstack.cloud](mailto:info@localstack.cloud). (Note: Please do not post any personal details or private information in any of the public communication channels!)
+For any administrative questions regarding your account (e.g., subscriptions, billing), please contact us directly at [support@localstack.cloud](mailto:support@localstack.cloud). (Note: Please do not post any personal details or private information in any of the public communication channels!)

--- a/content/dev-contest/contest.script.js
+++ b/content/dev-contest/contest.script.js
@@ -60,7 +60,7 @@ function onContestSignup() {
         })
         .catch(error => {
             console.log(error);
-            alert("Sorry, there was an error with your signup: " + error + ". Please contact us at info@localstack.cloud")
+            alert("Sorry, there was an error with your signup: " + error + ". Please contact us at support@localstack.cloud")
             toggleLoading(button);
         });
 

--- a/content/educational-license/index.md
+++ b/content/educational-license/index.md
@@ -27,23 +27,24 @@ How can LocalStack Education License help you?
 - The license should not be shared with any third parties.
 
 ## Application
+
 <div class="overlay-card h-100 p-4 p-md-5 p-lg-6">
-<script> 
-  hbspt.forms.create({ 
-    region: "eu1", portalId: "26596507", formId: "1f3a9b60-5ffa-46d7-b125-77a7a9d161fc" 
-  });   
+<script>
+  hbspt.forms.create({
+    region: "eu1", portalId: "26596507", formId: "1f3a9b60-5ffa-46d7-b125-77a7a9d161fc"
+  });
 </script>
 </div>
 
 ## Renewal of License
 
-To renew your license, please send an email to [info@localstack.cloud](mailto:info@localstack.cloud) with a proof of your student/teacher status.
+To renew your license, please send an email to [support@localstack.cloud](mailto:support@localstack.cloud) with a proof of your student/teacher status.
 
 ## Frequently asked questions
 
 - Where can I get help?
 
-  LocalStack has a great [documentation](https://docs.localstack.cloud/overview/) which serves as a reference for all the features and how to use them across the community and professional edition. We also have a Slack community where you can ask questions and get help from other users. Drop a mail at [info@localstack.cloud](mailto:info@localstack.cloud) to get an invite or join through our [Slack invite](http://slack.localstack.cloud/).
+  LocalStack has a great [documentation](https://docs.localstack.cloud/overview/) which serves as a reference for all the features and how to use them across the community and professional edition. We also have a Slack community where you can ask questions and get help from other users. Send an e-mail at [support@localstack.cloud](mailto:support@localstack.cloud) to get an invite or join through our [Slack invite](http://slack.localstack.cloud/).
 
 - How can I prove my student/teacher status?
 

--- a/content/faq/5-slack-invite/index.md
+++ b/content/faq/5-slack-invite/index.md
@@ -4,4 +4,4 @@ question: "How can I get a Slack invite?"
 tags: ['general']
 ---
 
-Users receive an invite after signing up to the LocalStack app on [app.localstack.cloud](https://app.localstack.cloud). You can also directly sign-up for our Slack workspace through our [Slack invite](http://slack.localstack.cloud/). Otherwise please reach out to [info@localstack.cloud](mailto:info@localstack.cloud).
+Users receive an invite after signing up to the LocalStack app on [app.localstack.cloud](https://app.localstack.cloud). You can also directly sign-up for our Slack workspace through our [Slack invite](http://slack.localstack.cloud/). Otherwise please reach out to [support@localstack.cloud](mailto:support@localstack.cloud).

--- a/content/open-source-sponsorship/index.md
+++ b/content/open-source-sponsorship/index.md
@@ -26,7 +26,7 @@ If your project meets the terms of these eligibility criteria, don't hesitate to
 
 - Where can I get help?
 
-  LocalStack has excellent [documentation](https://docs.localstack.cloud/overview/), which is our central reference for all the features and toolings. We also have a Slack community where you can ask questions and get help from other users. Drop a mail at [info@localstack.cloud](mailto:info@localstack.cloud) to get an invite or join through our [Slack invite](http://slack.localstack.cloud/).
+  LocalStack has excellent [documentation](https://docs.localstack.cloud/overview/), which is our central reference for all the features and toolings. We also have a Slack community where you can ask questions and get help from other users. Drop a mail at [support@localstack.cloud](mailto:support@localstack.cloud) to get an invite or join through our [Slack invite](http://slack.localstack.cloud/).
 
 - How can I prove my maintainer status?
 

--- a/content/privacy-policy/index.md
+++ b/content/privacy-policy/index.md
@@ -76,16 +76,16 @@ The Company may use Personal Data for the following purposes:
 * To manage Your Account: to manage Your registration as a user of the Service. The Personal Data You provide can give You access to different functionalities of the Service that are available to You as a registered user.
 * For the performance of a contract: the development, compliance and undertaking of the purchase contract for the products, items or services You have purchased or of any other contract with Us through the Service.
 * To contact You: To contact You by email, telephone calls, SMS, or other equivalent forms of electronic communication regarding updates or informative communications related to the functionalities, products or contracted services, including the security updates, when necessary or reasonable for their implementation.
-*  To provide You with news, special offers and general information about other goods, services and events which we offer that are similar to those that you have already purchased or enquired about unless You have opted not to receive such information.
-*  To manage Your requests: To attend and manage Your requests to Us.
+* To provide You with news, special offers and general information about other goods, services and events which we offer that are similar to those that you have already purchased or enquired about unless You have opted not to receive such information.
+* To manage Your requests: To attend and manage Your requests to Us.
 
 We may share your personal information in the following situations:
 
-*  With Service Providers: We may share Your personal information with Service Providers to monitor and analyze the use of our Service, to show advertisements to You to help support and maintain Our Service, to contact You, to advertise on third party websites to You after You visited our Service, or for payment processing.
-*  For Business transfers: We may share or transfer Your personal information in connection with, or during negotiations of, any merger, sale of Company assets, financing, or acquisition of all or a portion of our business to another company.
-*  With Affiliates: We may share Your information with Our affiliates, in which case we will require those affiliates to honor this Privacy Policy. Affiliates include Our parent company and any other subsidiaries, joint venture partners or other companies that We control or that are under common control with Us.
-*  With Business partners: We may share Your information with Our business partners to offer You certain products, services or promotions.
-*  With other users: when You share personal information or otherwise interact in the public areas with other users, such information may be viewed by all users and may be publicly distributed outside. If You interact with other users or register through a Third-Party Social Media Service, Your contacts on the Third-Party Social Media Service may see You name, profile, pictures and description of Your activity. Similarly, other users may be able to view descriptions of Your activity, communicate with You and view Your profile.
+* With Service Providers: We may share Your personal information with Service Providers to monitor and analyze the use of our Service, to show advertisements to You to help support and maintain Our Service, to contact You, to advertise on third party websites to You after You visited our Service, or for payment processing.
+* For Business transfers: We may share or transfer Your personal information in connection with, or during negotiations of, any merger, sale of Company assets, financing, or acquisition of all or a portion of our business to another company.
+* With Affiliates: We may share Your information with Our affiliates, in which case we will require those affiliates to honor this Privacy Policy. Affiliates include Our parent company and any other subsidiaries, joint venture partners or other companies that We control or that are under common control with Us.
+* With Business partners: We may share Your information with Our business partners to offer You certain products, services or promotions.
+* With other users: when You share personal information or otherwise interact in the public areas with other users, such information may be viewed by all users and may be publicly distributed outside. If You interact with other users or register through a Third-Party Social Media Service, Your contacts on the Third-Party Social Media Service may see You name, profile, pictures and description of Your activity. Similarly, other users may be able to view descriptions of Your activity, communicate with You and view Your profile.
 
 ## Retention of Your Personal Data
 
@@ -147,7 +147,7 @@ As set out in locally applicable Personal Data protection law, You may have:
 
 * **The right to data portability** Under certain circumstances, You may have the right to receive the Personal Data concerning You, which You have provided to Us, in a structured, commonly used, and machine-readable format, and to transmit these Personal Data to another entity.
 
-If You make a request, we have one month to respond to You. If You would like to exercise any of these rights, please contact Us at our email: info@localstack.cloud
+If You make a request, we have one month to respond to You.If You would like to exercise any of these rights, please contact Us at our email: [info@localstack.cloud](mailto:info@localstack.cloud)
 
 ## Links to Other Websites
 
@@ -163,7 +163,7 @@ You are advised to review this Privacy Policy periodically for any changes. Chan
 
 ## How to contact Us
 
-If you have any questions or comments about this Privacy Policy or Our privacy practices, you can contact Us at any time at info@localstack.cloud
+If you have any questions or comments about this Privacy Policy or Our privacy practices, you can contact Us at any time at [info@localstack.cloud](mailto:info@localstack.cloud)
 
 ---
 Last updated: March, 2022 (2022.v1)

--- a/content/terms/index.md
+++ b/content/terms/index.md
@@ -16,6 +16,7 @@ If LocalStack makes material changes to these Terms, we will notify you by email
 Violation of any of the terms below will result in the termination of your Account. You agree to use the Service at your own risk.
 
 ## API USAGE TERMS
+
 Customers may access their LocalStack account data via an API (Application Program Interface). Any use of the API, including use of the API through a third-party product that accesses LocalStack, is bound by these Terms plus the following specific terms:
 
    1. You expressly understand and agree that LocalStack shall not be liable for any direct, indirect, incidental, special, consequential or exemplary damages, including but not limited to, damages for loss of profits, goodwill, use, data or other intangible losses (even if LocalStack has been advised of the possibility of such damages), resulting from your use of the API or third-party products that access data via the API.
@@ -62,12 +63,11 @@ You must notify us of any fee dispute within 15 days of the invoice date, and on
 
 All fees are exclusive of all taxes, levies, or duties imposed by taxing authorities, and you shall be responsible for payment of all such taxes, levies, or duties. You are responsible for all applicable sales, services, value-added, goods and services, withholding, tariffs and similar taxes or fees (collectively, "Taxes and Fees") imposed by any government entity or collecting agency based on the Services, except those Taxes and Fees based on our net income, or Taxes and Fees for which you have provided an exemption certificate. Additionally, if you do not satisfy your Tax and Fees obligations, you agree that you will be required to reimburse us for any Taxes and Fees paid on your behalf, and we may take steps to collect Taxes and Fees we have paid on your behalf. In all cases, you will pay the amounts due under this Agreement to us in full without any right of set-off or deduction.
 
-
 ## 3. TERM AND TERMINATION
 
 ### 3.1 Term
 
-The initial term commitment for your purchase of Services will be as specified on an Order (“Initial Term”) and begins on the Effective Date.   After the Initial Term, the Services will, unless otherwise specified in the Service Description for a particular Service, renew for subsequent periods of the same length as the previous Term. You may provide notice of non-renewal for each Service you do not wish to renew at https://app.localstack.cloud or in writing to info@LocalStack.cloud. For monthly subscriptions, the cancellation is effective with the end of the then-current subscription period. For annual and multi-year Terms, notice of non-renewal must be provided no later than 60 days before the end of the Term, or then-current renewal term, or signs a new order form with a new term, as applicable. You will not receive any refunds due to early Service termination. We may agree to align the invoicing under multiple Orders but this will not reduce the term of any Order. Terminating specific Services does not affect the term of any other Services still in effect. If we permit you to reinstate Services at any time after termination, you agree that you will be bound by the then-current Terms and the renewal date that was in effect as of the effective termination date.
+The initial term commitment for your purchase of Services will be as specified on an Order (“Initial Term”) and begins on the Effective Date.   After the Initial Term, the Services will, unless otherwise specified in the Service Description for a particular Service, renew for subsequent periods of the same length as the previous Term. You may provide notice of non-renewal for each Service you do not wish to renew at <https://app.localstack.cloud> or in writing to [info@localstack.cloud](mailto:info@localstack.cloud). For monthly subscriptions, the cancellation is effective with the end of the then-current subscription period. For annual and multi-year Terms, notice of non-renewal must be provided no later than 60 days before the end of the Term, or then-current renewal term, or signs a new order form with a new term, as applicable. You will not receive any refunds due to early Service termination. We may agree to align the invoicing under multiple Orders but this will not reduce the term of any Order. Terminating specific Services does not affect the term of any other Services still in effect. If we permit you to reinstate Services at any time after termination, you agree that you will be bound by the then-current Terms and the renewal date that was in effect as of the effective termination date.
 
 ### 3.2 Termination for Cause
 
@@ -115,6 +115,7 @@ NEITHER PARTY WILL BE LIABLE TO THE OTHER PARTY OR TO ANY OTHER PERSON FOR ANY I
 EXCEPT FOR YOUR BREACH OF SECTIONS 1.2 OR 4 AND YOUR INDEMNIFICATION OBLIGATIONS, AND TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE TOTAL CUMULATIVE LIABILITY OF EITHER PARTY AND THEIR RESPECTIVE LICENSORS AND SUPPLIERS ARISING OUT OF THIS AGREEMENT IS LIMITED TO THE SUM OF THE AMOUNTS PAID FOR THE APPLICABLE SERVICE DURING THE 12 MONTHS IMMEDIATELY PRECEDING THE INCIDENT GIVING RISE TO THE LIABILITY. THE FOREGOING DOES NOT LIMIT YOUR OBLIGATIONS TO PAY ANY UNDISPUTED FEES AND OTHER AMOUNTS DUE UNDER ANY ORDER.
 
 ## 9. Cookies
+
 A cookie is a small file containing a string of characters that is sent to your computer when you visit a website. Cookies help to improve your user experience. When you visit the site again, the cookie allows that site to recognize your browser. Cookies may store user preferences and other information. You can configure your browser to refuse all cookies or to indicate when a cookie is being sent. However, some website features or services may not function properly without cookies.
 
 ## 10. ADDITIONAL TERMS
@@ -153,7 +154,7 @@ Neither party may assign its rights or delegate its duties under the Agreement e
 
 ### 10.9 Notices
 
-We may provide notice to the email last designated on your account, electronically via postings on our website, or in-product notices. Unless specified elsewhere in this Agreement, notices should be sent to us via email to info@localstack.cloud and we will send notices to the address last designated on your account. Notice is given when the email is sent, or if posted electronically, upon posting.
+We may provide notice to the email last designated on your account, electronically via postings on our website, or in-product notices. Unless specified elsewhere in this Agreement, notices should be sent to us via email to [info@localstack.cloud](mailto:info@localstack.cloud) and we will send notices to the address last designated on your account. Notice is given when the email is sent, or if posted electronically, upon posting.
 
 ### 10.10 General Terms
 

--- a/layouts/partials/misc/contacts.html
+++ b/layouts/partials/misc/contacts.html
@@ -25,7 +25,7 @@
         </div>
         <div class="col col-md-7">
             <div class="overlay-card h-100 p-4 p-md-5 p-lg-5 ">
-                <h2 class="mb-4">Have a Question?</h2>
+                <h2 class="mb-4">Need help?</h2>
                 <script>
                 hbspt.forms.create({
                     region: "eu1",

--- a/layouts/partials/misc/contacts.html
+++ b/layouts/partials/misc/contacts.html
@@ -2,15 +2,15 @@
     <div class="d-flex flex-column flex-md-row gap-4">
         <div class="col col-md-5 d-flex flex-column gap-4 flex-grow-1 jusitfy-space-between">
                 {{ partial "misc/contact-card.html" (dict "contactName" "Discussion"
-                "text" "Our new discussion platform:"
+                "text" "Join our discussion platform:"
                 "link" "discuss.localstack.cloud"
                 "type" "link"
                 ) }}
-                {{ partial "misc/contact-card.html" (dict "contactName" "E-mail"
-                "text" "For any administrative questions"
+                {{/*  {{ partial "misc/contact-card.html" (dict "contactName" "E-mail"
+                "text" "For any support questions"
                 "link" "info@localstack.cloud"
                 "type" "mail"
-                ) }}
+                ) }}  */}}
                 {{ partial "misc/contact-card.html" (dict "contactName" "Slack"
                 "text" "Please join our Slack community"
                 "link" "slack.localstack.cloud"
@@ -24,8 +24,8 @@
             {{/* TODO: discuss */}}
         </div>
         <div class="col col-md-7">
-            <div class="overlay-card h-100 p-4 p-md-5 p-lg-6">
-                <p class="pb-4">You can also get in touch with us directly via this form.</p>
+            <div class="overlay-card h-100 p-4 p-md-5 p-lg-5 ">
+                <h2 class="mb-4">Have a Question?</h2>
                 <script>
                 hbspt.forms.create({
                     region: "eu1",
@@ -45,7 +45,7 @@
         const email = document.getElementById('email')
         const phonenumber = document.getElementById('phonenumber')
         const message = document.getElementById('message')
-        const link = "mailto:info@localstack.cloud?subject="+firstname.value+" "+lastname.value+" "+phonenumber.value+"&body="+message.value
+        const link = "mailto:support@localstack.cloud?subject="+firstname.value+" "+lastname.value+" "+phonenumber.value+"&body="+message.value
         window.location.href = link
     }
 </script>

--- a/layouts/partials/misc/contacts.html
+++ b/layouts/partials/misc/contacts.html
@@ -1,6 +1,6 @@
 <div class="container mb-6 mt-n5">
     <div class="d-flex flex-column flex-md-row gap-4">
-        <div class="col col-md-5 d-flex flex-column gap-4 flex-grow-1 jusitfy-space-between">
+        <div class="col col-md-5 d-flex flex-column gap-4 flex-grow-1 justify-content-between">
                 {{ partial "misc/contact-card.html" (dict "contactName" "Discussion"
                 "text" "Join our discussion platform:"
                 "link" "discuss.localstack.cloud"


### PR DESCRIPTION
- Updated Markdown formatting
- Updated <info@localstack.cloud> on specific parts of the website (contact) to <support@localstack.cloud> 
- Removed/Updated some parts of the <https://localstack.cloud/contact> page 
![image](https://github.com/localstack/localstack.github.io/assets/97876429/b5210ae4-6f2a-48cc-8fb7-4fb7a5978344)
